### PR TITLE
Reworked Camera References

### DIFF
--- a/BabyStepsMultiplayerClient/Player/LocalPlayer.cs
+++ b/BabyStepsMultiplayerClient/Player/LocalPlayer.cs
@@ -11,7 +11,6 @@ namespace BabyStepsMultiplayerClient.Player
         public static LocalPlayer Instance;
 
         public PlayerMovement playerMovement;
-        public Transform camera;
         public GameObject cinemachineBrainObj;
         public CinemachineBrain cinemachineBrain;
         public Material pmSuitMaterial;
@@ -34,10 +33,9 @@ namespace BabyStepsMultiplayerClient.Player
             if (playerMovement != null)
                 pmSuitMaterial = playerMovement.suitMat;
 
-            camera = baseObject.transform.Find("GameCam");
-
             cinemachineBrainObj = GameObject.Find("BigManagerPrefab/Camera");
-            cinemachineBrain = cinemachineBrainObj.GetComponent<CinemachineBrain>();
+            if (cinemachineBrainObj != null)
+                cinemachineBrain = cinemachineBrainObj.GetComponent<CinemachineBrain>();
 
             // Base Initialization
             base.Initialize();
@@ -51,6 +49,22 @@ namespace BabyStepsMultiplayerClient.Player
         {
             SetSuitColor(Color.white);
             ResetSuitColor();
+        }
+
+        public GameObject GetCameraObject()
+        {
+            if (cinemachineBrain == null)
+                return null;
+
+            var virtualCam = cinemachineBrain.ActiveVirtualCamera;
+            if (virtualCam == null) 
+                return null;
+
+            var virtualCamObj = virtualCam.VirtualCameraGameObject;
+            if (virtualCamObj == null)
+                return null;
+
+            return virtualCamObj;
         }
 
         public void ApplySuitColor()

--- a/BabyStepsMultiplayerClient/Player/NameTagUI.cs
+++ b/BabyStepsMultiplayerClient/Player/NameTagUI.cs
@@ -47,13 +47,15 @@ namespace BabyStepsMultiplayerClient.Player
             if (baseObject == null)
                 return;
 
-            if ((LocalPlayer.Instance != null)
-                && (LocalPlayer.Instance.camera != null))
+            if (LocalPlayer.Instance != null)
             {
-
-                float distance = Vector3.Distance(LocalPlayer.Instance.camera.position, baseObject.transform.position);
-                SetActive(distance <= 100f);
-                RotateTowardsCamera(LocalPlayer.Instance.cinemachineBrain.ActiveVirtualCamera.VirtualCameraGameObject.transform.position);
+                GameObject camera = LocalPlayer.Instance.GetCameraObject();
+                if (camera != null)
+                {
+                    float distance = Vector3.Distance(camera.transform.position, baseObject.transform.position);
+                    SetActive(distance <= 100f);
+                    RotateTowardsCamera(camera.transform.position);
+                }
             }
         }
 
@@ -74,10 +76,12 @@ namespace BabyStepsMultiplayerClient.Player
             baseObject.transform.SetParent(parent, false);
             baseObject.transform.localPosition = positionOffset;
 
-            if ((LocalPlayer.Instance != null)
-                && (LocalPlayer.Instance.camera != null)
-                && baseObject.activeSelf)
-                RotateTowardsCamera(LocalPlayer.Instance.cinemachineBrain.ActiveVirtualCamera.VirtualCameraGameObject.transform.position);
+            if (LocalPlayer.Instance != null)
+            {
+                GameObject camera = LocalPlayer.Instance.GetCameraObject();
+                if (camera != null)
+                    RotateTowardsCamera(camera.transform.position);
+            }
         }
 
         public void SetText(string text)

--- a/BabyStepsMultiplayerClient/Player/RemotePlayer.cs
+++ b/BabyStepsMultiplayerClient/Player/RemotePlayer.cs
@@ -218,9 +218,11 @@ namespace BabyStepsMultiplayerClient.Player
             {
                 if ((LocalPlayer.Instance.rootBone != null) && firstBoneInterpRan)
                     distanceFromPlayer = Vector3.Distance(LocalPlayer.Instance.rootBone.position, rootBone.transform.position);
-                if (LocalPlayer.Instance.camera != null)
+
+                GameObject camera = LocalPlayer.Instance.GetCameraObject();
+                if (camera != null)
                 {
-                    float distance = Vector3.Distance(LocalPlayer.Instance.camera.position, rootBone.transform.position);
+                    float distance = Vector3.Distance(camera.transform.position, rootBone.transform.position);
                     FadeByDistance(distance);
                 }
             }


### PR DESCRIPTION
This makes usage of the LocalPlayer camera into a central method that gets the active CinemachineBrain camera when needed
Removes the need for preset camera references when CinemachineBrain can be used dynamically