### PR TITLE
Recreate Config File if Tomlet fails to Parse

### DIFF
--- a/BabyStepsMultiplayerClient/BabyStepsMultiplayerClient.csproj
+++ b/BabyStepsMultiplayerClient/BabyStepsMultiplayerClient.csproj
@@ -65,6 +65,8 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" ExcludeAssets="Runtime" />
 	  
 		<PackageReference Include="LiteNetLib" Version="1.3.1" />
+	  
+		<PackageReference Include="Samboy063.Tomlet" Version="6.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/BabyStepsMultiplayerClient/Config/ConfigCategory.cs
+++ b/BabyStepsMultiplayerClient/Config/ConfigCategory.cs
@@ -10,17 +10,15 @@ namespace BabyStepsMultiplayerClient.Config
         public MelonPreferences_Category Category;
         public string FileExt = ".cfg";
 
-        public virtual eConfigType ConfigType { get; set; }
         public virtual string ID { get; set; }
         public virtual string DisplayName { get; set; }
 
         public ConfigCategory()
         {
             Setup(MelonEnvironment.UserDataDirectory,
-                "BabyStepsClientConfig", 
+                "BabyStepsClientConfig",
                 ID,
-                DisplayName, 
-                ConfigType);
+                DisplayName);
 
             if (!_allCategories.ContainsKey(ID))
                 _allCategories[ID] = this;
@@ -29,34 +27,30 @@ namespace BabyStepsMultiplayerClient.Config
         public ConfigCategory(string folderPath,
             string fileName,
             string categoryID,
-            string categoryDisplayName,
-            eConfigType categoryType)
-            => Setup(folderPath, fileName, categoryID, categoryDisplayName, categoryType);
+            string categoryDisplayName)
+            => Setup(folderPath, fileName, categoryID, categoryDisplayName);
 
         public void Setup(string folderPath,
             string fileName,
             string categoryID,
-            string categoryDisplayName,
-            eConfigType categoryType)
+            string categoryDisplayName)
         {
             if (string.IsNullOrEmpty(categoryDisplayName)
                 || string.IsNullOrWhiteSpace(categoryDisplayName))
                 categoryDisplayName = categoryID;
 
+            string filePath = Path.Combine(folderPath, $"{fileName}{FileExt}");
+
+
+
             ID = categoryID;
             DisplayName = categoryDisplayName;
-            ConfigType = categoryType;
 
             Category = MelonPreferences.GetCategory(ID);
             if (Category == null)
             {
                 Category = MelonPreferences.CreateCategory(ID, DisplayName, true, false);
                 Category.DestroyFileWatcher();
-
-                if (!Directory.Exists(folderPath))
-                    Directory.CreateDirectory(folderPath);
-
-                string filePath = Path.Combine(folderPath, $"{fileName}{FileExt}");
                 Category.SetFilePath(filePath, true, false);
             }
 

--- a/BabyStepsMultiplayerClient/Config/ConfigCategory.cs
+++ b/BabyStepsMultiplayerClient/Config/ConfigCategory.cs
@@ -1,5 +1,6 @@
 ﻿using MelonLoader;
 using MelonLoader.Utils;
+using Tomlet;
 
 namespace BabyStepsMultiplayerClient.Config
 {
@@ -41,7 +42,20 @@ namespace BabyStepsMultiplayerClient.Config
 
             string filePath = Path.Combine(folderPath, $"{fileName}{FileExt}");
 
-
+            // Herp:
+            // This double checks if the config is readable by the Tomlet Parser
+            // If not then it deletes the file to be recreated
+            if (File.Exists(filePath))
+                try
+                {
+                    var doc = TomlParser.ParseFile(filePath);
+                    if (doc == null)
+                        throw new NullReferenceException();
+                }
+                catch 
+                {
+                    File.Delete(filePath);
+                }
 
             ID = categoryID;
             DisplayName = categoryDisplayName;

--- a/BabyStepsMultiplayerClient/Config/ConfigCategory.cs
+++ b/BabyStepsMultiplayerClient/Config/ConfigCategory.cs
@@ -60,16 +60,12 @@ namespace BabyStepsMultiplayerClient.Config
             ID = categoryID;
             DisplayName = categoryDisplayName;
 
-            Category = MelonPreferences.GetCategory(ID);
-            if (Category == null)
-            {
-                Category = MelonPreferences.CreateCategory(ID, DisplayName, true, false);
-                Category.DestroyFileWatcher();
-                Category.SetFilePath(filePath, true, false);
-            }
+            Category = MelonPreferences.CreateCategory(ID, DisplayName, true, false);
+            Category.DestroyFileWatcher();
+            Category.SetFilePath(filePath, true, false);
 
             CreatePreferences();
-            Category.SaveToFile(false);
+            Save();
         }
 
         public virtual void CreatePreferences() { }

--- a/BabyStepsMultiplayerClient/Config/ConnectionConfig.cs
+++ b/BabyStepsMultiplayerClient/Config/ConnectionConfig.cs
@@ -8,11 +8,7 @@ namespace BabyStepsMultiplayerClient.Config
         internal MelonPreferences_Entry<int> Port;
         internal MelonPreferences_Entry<string> Password;
 
-        public override eConfigType ConfigType
-            => eConfigType.Connection;
         public override string ID
-            => "Connection";
-        public override string DisplayName
             => "Connection";
 
         public override void CreatePreferences()

--- a/BabyStepsMultiplayerClient/Config/PlayerConfig.cs
+++ b/BabyStepsMultiplayerClient/Config/PlayerConfig.cs
@@ -9,11 +9,7 @@ namespace BabyStepsMultiplayerClient.Config
         internal MelonPreferences_Entry<Color> SuitColor;
         internal MelonPreferences_Entry<bool> Collisions;
 
-        public override eConfigType ConfigType
-            => eConfigType.Player;
         public override string ID
-            => "Player";
-        public override string DisplayName
             => "Player";
 
         public override void CreatePreferences()

--- a/BabyStepsMultiplayerClient/Config/eConfigType.cs
+++ b/BabyStepsMultiplayerClient/Config/eConfigType.cs
@@ -1,8 +1,0 @@
-﻿namespace BabyStepsMultiplayerClient.Config
-{
-    public enum eConfigType : int
-    {
-        Connection,
-        Player,
-    }
-}


### PR DESCRIPTION
If the Tomlet Parser that ``MelonPreferences`` uses fails to read the Config file this will delete and recreate it